### PR TITLE
Move Test Dependencies Into Test Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 UNMERGED BRANCH -CHANGES FROM OTHER SAMPLY TEAMS MISSING
 
- ## License
-        
- Copyright 2020 The Samply Development Community
-        
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-        
- http://www.apache.org/licenses/LICENSE-2.0
-        
- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
- 
+## License
+       
+Copyright 2020 - 2021 The Samply Community
+       
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+       
+http://www.apache.org/licenses/LICENSE-2.0
+       
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <datatables.version>1.10.16</datatables.version>
 
         <!-- JUnit testing -->
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
+        <junit-jupiter.version>5.8.1</junit-jupiter.version>
         <junit-platform.version>1.1.0</junit-platform.version>
         <hamcrest-library.version>2.2</hamcrest-library.version>
 
@@ -185,16 +185,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Test dependencies should be always in test scope. Otherwise, they slip into production artifacts.

Also updated Junit5 to v5.8.1 and removed junit-platform-launcher because I don't see any use to it.